### PR TITLE
Add missing changes for 0.3.0 fix

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -24,6 +24,8 @@ before_deploy:
   cp "$TRAVIS_BUILD_DIR/lib/libmtp.dylib" "$TRAVIS_BUILD_DIR/prebuilds/darwin-x64/";
   install_name_tool -change "/usr/local/opt/libmtp/lib/libmtp.9.dylib" "@loader_path/libmtp.dylib" "$TRAVIS_BUILD_DIR/prebuilds/darwin-x64/node-napi.node";
   otool -L "$TRAVIS_BUILD_DIR/prebuilds/darwin-x64/node-napi.node";
+  install_name_tool -change "/usr/local/opt/libmtp/lib/libmtp.9.dylib" "@loader_path/libmtp.dylib" "$TRAVIS_BUILD_DIR/prebuilds/darwin-x64/electron-napi.node";
+  otool -L "$TRAVIS_BUILD_DIR/prebuilds/darwin-x64/electron-napi.node";
   fi
 - tar --create --verbose --file="$ARCHIVE_NAME" --directory "$TRAVIS_BUILD_DIR/prebuilds"
   .

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "node-mtp",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "description": "Access devices over MTP using Node.js",
   "main": "index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
   "homepage": "https://github.com/tidepool-org/node-mtp#readme",
   "dependencies": {
     "napi-macros": "1.7.0",
-    "node-gyp-build": "3.4.0"
+    "node-gyp-build": "3.5.0"
   },
   "devDependencies": {
     "prebuildify": "2.7.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -96,10 +96,10 @@ node-abi@^2.0.0:
   dependencies:
     semver "^5.4.1"
 
-node-gyp-build@3.4.0:
-  version "3.4.0"
-  resolved "https://registry.yarnpkg.com/node-gyp-build/-/node-gyp-build-3.4.0.tgz#f8f62507e65f152488b28aac25d04b9d79748cf7"
-  integrity sha512-YoviGBJYGrPdLOKDIQB0sKxuKy/EEsxzooNkOZak4vSTKT/qH0Pa6dj3t1MJjEQGsefih61IyHDmO1WW7xOFfw==
+node-gyp-build@3.5.0:
+  version "3.5.0"
+  resolved "https://registry.yarnpkg.com/node-gyp-build/-/node-gyp-build-3.5.0.tgz#92f7c6517d1f90e2795a1cd49a59c6487b4f1cdb"
+  integrity sha512-qjEE8eIWVyqZhkAFUzytGpOGvLHeX5kXBB6MYyTOCPZBrBlsLyXAAzTsp/hWMbVlg8kVpzDJCZZowIrnKpwmqQ==
 
 once@^1.3.1, once@^1.4.0:
   version "1.4.0"


### PR DESCRIPTION
Looks like I was a bit too hasty in the 0.3.0 fix. There were some additional changes that I'm now adding as a hotfix to get it out and test it.

The main issue here is that there is a NAPI bug in Electron/Node that requires some workarounds. I've already done this for `lzo-decompress`, but need to make the same changes to `node-mtp`.